### PR TITLE
testing score directly

### DIFF
--- a/score.rb
+++ b/score.rb
@@ -4,7 +4,7 @@ class Score
   WINNING_SCORE = 11
   MIN_DIFFERENCE = 2
 
-  WINNING_SET_SCORE = 2
+  WINNING_SET_SCORE = 3
   MIN_SET_DIFFERENCE = 1
 
   def initialize(input)

--- a/score.rb
+++ b/score.rb
@@ -102,5 +102,15 @@ class Score
     }
     EOF
   end
+  
+  def ==(o) 
+    return false unless o.class == self.class 
+    puts "using eq"
+    o.p1_score == p1_score &&
+      o.p2_score == p2_score &&
+      o.set == set &&
+      o.p1_set_score == p1_set_score &&
+      o.p2_set_score == p2_set_score 
+  end
 
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -20,18 +20,23 @@ RSpec.describe Game  do
 
   it "can undo" do 
     game = game_with_input_sequence(%w(l l r r l))
-    expect(game.score.p1_score).to eq(3)
+    original_score = game.score 
+    game.handle_input('r')
+    expect(game.score).to_not eq(original_score)
     game.undo
-    expect(game.score.p1_score).to eq(2)
+    expect(game.score).to eq(original_score)
   end
   
   it "can undo across sets" do
-    game = game_with_input_sequence(%w(l) * 12)
-    expect(game.score.p1_set_score).to eq(1)
+    game = game_with_input_sequence(%w(l) * 10)
+    original_score = game.score
+    game.handle_input('l')
+    game.handle_input('l')
+    expect(game.score).to_not eq(original_score)
     #needs to also undo the confirmation click that is needed to get to the next set
     game.undo
     game.undo 
-    expect(game.score.p1_set_score).to eq(0)
+    expect(game.score).to eq(original_score)
   end
 
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -10,89 +10,28 @@ RSpec.describe Game  do
     end
     game
   end
-  
 
-  it "handles a valid input sequence" do
-    input = %w(l l r r l l)
-    game = game_with_input_sequence(input)
-    expect(game.p1_score).to eq(4)
-    expect(game.p2_score).to eq(2)
-    expect(game.set).to eq(1)
-  end
-
-  it "can be rerun" do
-    input = %w(l l r r l l)
-    game = game_with_input_sequence(input)
-    expect(game.p1_score).to eq(4)
-    expect(game.p2_score).to eq(2)
-    expect(game.set).to eq(1)
-    %w(l r).each do |c| 
-      game.handle_input(c)
-    end
-    expect(game.p1_score).to eq(5)
-    expect(game.p2_score).to eq(3)
-  end
-
-  it "handles changeover" do
-    input = %w(l) * 13
-    game = game_with_input_sequence(input)
-    expect(game.p1_score).to eq(0)
-    expect(game.p2_score).to eq(1)
-    expect(game.p1_set_score).to eq(1)
-    expect(game.set).to eq(2)
-
-  end
-
-  it "knows who won" do
-    #after 3*1b -r we are at 10-0 in set 3
-    input = %w(l)*12 + %w(r)*12 + %w(l)*10
-    game = game_with_input_sequence(input)
-    expect(game.winner).to be_nil
-    game.handle_input('l')
-    expect(game.winner).to eq(1)
-  end
-
-  it "is aware of minimum difference" do
-    #input = %w(1) * (3*11-1)
+  it "can delegate input to score" do
+    score = game_with_input_sequence(%w(l l r r l l)).score
+    expect(score.p1_score).to eq(4)
+    expect(score.p2_score).to eq(2)
+    expect(score.set).to eq(1)
   end
 
   it "can undo" do 
     game = game_with_input_sequence(%w(l l r r l))
-    expect(game.p1_score).to eq(3)
+    expect(game.score.p1_score).to eq(3)
     game.undo
-    expect(game.p1_score).to eq(2)
+    expect(game.score.p1_score).to eq(2)
   end
   
   it "can undo across sets" do
     game = game_with_input_sequence(%w(l) * 12)
-    expect(game.p1_set_score).to eq(1)
+    expect(game.score.p1_set_score).to eq(1)
     #needs to also undo the confirmation click that is needed to get to the next set
     game.undo
     game.undo 
-    expect(game.p1_set_score).to eq(0)
-  end
-
-  it "ignores further input after game is finished" do
-    game = game_with_input_sequence(%w(l)*12 + %w(r)*12 + %w(l)*11)
-    expect(game.game_finished?).to eq(true)
-    expect(game.set).to eq(3)
-    expect(game.p1_score).to eq(11)
-    game.handle_input('l')
-    expect(game.game_finished?).to eq(true)
-    expect(game.set).to eq(3)
-    expect(game.p1_score).to eq(11)
-  end
-
-  it "handles chageover in the third set" do
-    game = game_with_input_sequence(%w(l)*12*4 + %w(l)*7)
-    expect(game.p1_score).to eq(7)
-    expect(game.p2_score).to eq(0)
-    game.handle_input('l')
-    expect(game.p1_score).to eq(7)
-    expect(game.p2_score).to eq(0)
-    game.handle_input('l')
-    expect(game.p1_score).to eq(7)
-    expect(game.p2_score).to eq(1)
+    expect(game.score.p1_set_score).to eq(0)
   end
 
 end

--- a/spec/models/score_spec.rb
+++ b/spec/models/score_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require_relative "../../score"
+
+RSpec.describe Score  do
+  def score(input)
+    #this is in a method because we will probably want to set WINNING_SET_SCORE here in the future
+    Score.new(input)
+  end
+
+  it "handles a valid input sequence" do
+    score = score(%w(l l r r l l))
+    expect(score.p1_score).to eq(4)
+    expect(score.p2_score).to eq(2)
+    expect(score.set).to eq(1)
+  end
+
+
+  it "handles changeover" do
+    input = %w(l) * 13
+    score = score(input)
+    expect(score.p1_score).to eq(0)
+    expect(score.p2_score).to eq(1)
+    expect(score.p1_set_score).to eq(1)
+    expect(score.set).to eq(2)
+  end
+
+  it "knows who won" do
+    #after 3*1b -r we are at 10-0 in set 3
+    input = %w(l)*12 + %w(r)*12 + %w(l)*10
+    score = score(input)
+    expect(score.winner).to be_nil
+    score = score(input+['l'])
+    expect(score.winner).to eq(1)
+  end
+
+  #it "is aware of minimum difference" do
+  #  #input = %w(1) * (3*11-1)
+  #end
+
+
+  it "ignores further input after game is finished" do
+    input = %w(l)*12 + %w(r)*12 + %w(l)*11
+    score = score(input)
+    expect(score.game_finished?).to eq(true)
+    expect(score.set).to eq(3)
+    expect(score.p1_score).to eq(11)
+    score = score(input+['l'])
+    expect(score.game_finished?).to eq(true)
+    expect(score.set).to eq(3)
+    expect(score.p1_score).to eq(11)
+  end
+
+  it "handles changeover in the third set" do
+    input = %w(l)*12*4 + %w(l)*7
+    score = score(input)
+    expect(score.p1_score).to eq(7)
+    expect(score.p2_score).to eq(0)
+    score = score(input+['l'])
+    expect(score.p1_score).to eq(7)
+    expect(score.p2_score).to eq(0)
+    score = score(input+['l', 'l'])
+    expect(score.p1_score).to eq(7)
+    expect(score.p2_score).to eq(1)
+  end
+end


### PR DESCRIPTION
Take a look at this @noniq.

## Things to discuss:

- `Game` spec uses `Score` directly to verify game can undo and delegate to score instead of mocking `Score`. I see no reason to go through the effort to mock `Score`. Do you? 
- `Score` is immutable, nonetheless I decided to keep the test structure like it was in game for now. I wanted to know what you think. Should...
```ruby
 it "knows who won" do
    #after 3*1b -r we are at 10-0 in set 3
    input = %w(l)*12 + %w(r)*12 + %w(l)*10
    score = score(input)
    expect(score.winner).to be_nil
    score = score(input+['l'])
    expect(score.winner).to eq(1)
end
```
...really be:
```ruby
 it "knows if a player won" do
    input = %w(l)*12 + %w(r)*12 + %w(l)*10
    input.push('l')
    score = score(input)
    expect(score.winner).to eq(1)
end
 it "knows if nobody won" do
    input = %w(l)*12 + %w(r)*12 + %w(l)*10
    score = score(input)
    expect(score.winner).to be_nil
end
```
Even though it makes sense to check if `Score` reports a false winner in the same test we are checking if it reports a right winner, the way we are doing it now feels a bit like checking if `add(-1,0)==-1` before checking if `add(1,0)==1` in a single test for add. 
More technically: we are checking two output equivalence classes in a single test. 
I am leaning towards the first solution:
Pros: fewer tests, fewer duplicate lines, it's okay to check two non-invalid equivalence classes in the same test
Cons: a single test can fail for multiple reasons

🔥 🔥 🔥 
